### PR TITLE
【knowhow】vimの設定を変更する

### DIFF
--- a/knowhow/vim/.vim/.netrwhist
+++ b/knowhow/vim/.vim/.netrwhist
@@ -1,0 +1,4 @@
+let g:netrw_dirhistmax  =10
+let g:netrw_dirhist_cnt =2
+let g:netrw_dirhist_1='/home/vagrant/projects/suburi/network/datasync'
+let g:netrw_dirhist_2='/home/vagrant/projects/suburi/network/datasync/snd'

--- a/knowhow/vim/.vim/autoload/cfi.vim
+++ b/knowhow/vim/.vim/autoload/cfi.vim
@@ -1,0 +1,316 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+" Define g:cfi_disable, and so on.
+runtime! plugin/cfi.vim
+
+
+let s:finder = {}
+
+let s:TYPE_STRING = type("")
+let s:TYPE_NUMBER = type(0)
+let s:TYPE_DICT = type({})
+
+
+
+function! cfi#load() "{{{
+    " Dummy function to load this file.
+endfunction "}}}
+
+function! cfi#get_func_name(...) "{{{
+    let NONE = ""
+    if g:cfi_disable
+        return NONE
+    endif
+    let dotfiletypes = a:0 ? a:1 : &l:filetype
+    if dotfiletypes ==# ''
+        return NONE
+    endif
+    let filetype = cfi#choose_finder_filetype(dotfiletypes)
+    if filetype ==# ''
+        return NONE
+    endif
+    let ctx = {'lnum': line('.'), 'col': col('.')}
+    let cache = s:get_cache(ctx, {})
+    if !empty(cache)
+        return cache.funcname
+    endif
+
+    let orig_view = winsaveview()
+    try
+        let val = s:finder[filetype].find(deepcopy(ctx))
+        if type(val) == s:TYPE_DICT
+            if !empty(val) && val.funcname !=# ''
+                let val.version = s:get_current_version()
+                call s:save_cache(ctx, val)
+                return val.funcname
+            else
+                return NONE
+            endif
+        elseif type(val) == s:TYPE_STRING
+            return val
+        endif
+        return NONE
+    finally
+        call winrestview(orig_view)
+    endtry
+endfunction "}}}
+
+if has('*undotree')
+    function! s:get_current_version() "{{{
+        return undotree().seq_cur
+    endfunction "}}}
+else
+    function! s:get_current_version() "{{{
+        return b:changedtick
+    endfunction "}}}
+endif
+
+function! cfi#format(fmt, default) "{{{
+    let name = cfi#get_func_name()
+    if name != ''
+        return printf(a:fmt, name)
+    else
+        return a:default
+    endif
+endfunction "}}}
+
+function! cfi#create_finder(filetype) "{{{
+    return extend({'is_ready': 0, 'phase': 0}, deepcopy(s:base_finder), 'keep')
+endfunction "}}}
+
+function! cfi#supported_filetype(filetype) "{{{
+    return cfi#supported_filetypes(a:filetype)
+endfunction "}}}
+
+function! cfi#supported_filetypes(dotfiletypes) "{{{
+    return cfi#choose_finder_filetype(a:dotfiletypes) !=# ''
+endfunction "}}}
+
+function! cfi#choose_finder_filetype(dotfiletypes) "{{{
+    return get(
+    \   filter(split(a:dotfiletypes, '\.'), 'has_key(s:finder, v:val)'),
+    \   0, '')
+endfunction "}}}
+
+function! cfi#register_finder(filetype, finder) "{{{
+    if has_key(s:finder, a:filetype)
+        return
+    endif
+    if !has_key(a:finder, 'find')
+    \   || !has_key(a:finder, 'get_func_name')
+    \   || !has_key(a:finder, 'find_begin')
+    \   || !has_key(a:finder, 'find_end')
+        call s:error('cfi#register_finder(): finder for ' . a:filetype
+        \          . ' does not have all required methods:'
+        \          . ' find(), get_func_name(), find_begin(), find_end()')
+        return
+    endif
+    let s:finder[a:filetype] = a:finder
+endfunction "}}}
+
+function! cfi#register_simple_finder(filetype, finder) "{{{
+    if has_key(s:finder, a:filetype)
+        return
+    endif
+    if !has_key(a:finder, 'find')
+        call s:error('cfi#register_finder(): finder for ' . a:filetype
+        \          . ' does not have required method:'
+        \          . ' find()')
+        return
+    endif
+    let s:finder[a:filetype] = a:finder
+endfunction "}}}
+
+function! cfi#get_finder(filetype) "{{{
+	if has_key(s:finder, a:filetype)
+		return s:finder[a:filetype]
+	endif
+endfunction "}}}
+
+" s:base_finder {{{
+let s:base_finder = {}
+
+function! s:base_finder.find(ctx) "{{{
+    let orig_pos = [a:ctx.lnum, a:ctx.col]
+    let NONE = {}
+    let ret = {}
+    let self._result = ret
+    let self.temp = {}
+
+    try
+        let self.phase = 1
+        let ret.begin_pos = self.find_begin()
+        if empty(ret.begin_pos)
+            return NONE
+        endif
+        if self.is_ready
+            let ret.funcname = self.get_func_name()
+        endif
+
+        let self.phase = 2
+        let ret.end_pos = self.find_end()
+        if empty(ret.end_pos)
+            return NONE
+        endif
+        if self.is_ready && get(ret, 'funcname', '') ==# ''
+            let ret.funcname = self.get_func_name()
+        endif
+        if ret.funcname ==# ''
+            return NONE
+        endif
+
+        " function's begin pos -> {original pos} -> function's end pos
+        if !self.in_function(orig_pos)
+            return NONE
+        endif
+
+        return ret
+    finally
+        let self.is_ready = 0
+        let self.phase = 0
+    endtry
+endfunction "}}}
+
+function! s:base_finder.in_function(pos) "{{{
+    return self.pos_between(
+    \   self._result.begin_pos,
+    \   a:pos,
+    \   self._result.end_pos,
+    \)
+endfunction "}}}
+
+function! s:base_finder.pos_between(pos1, pos2, pos3) "{{{
+    return s:pos_is_less_than(a:pos1, a:pos2)
+    \   && s:pos_is_less_than(a:pos2, a:pos3)
+endfunction "}}}
+
+function! s:base_finder.get_begin_pos() "{{{
+    return self._result.begin_pos
+endfunction "}}}
+
+function! s:base_finder.get_end_pos() "{{{
+    return self._result.end_pos
+endfunction "}}}
+
+" }}}
+
+
+
+function! s:get_cache(ctx, else) "{{{
+    if exists('b:cfi_last_result')
+        let key = join([s:get_current_version(), a:ctx.lnum, a:ctx.col], '|')
+        if has_key(b:cfi_last_result, key)
+            return b:cfi_last_result[key]
+        endif
+    endif
+    if exists('b:cfi_cache_list')
+        let [index, found] = s:bsearch_nearest_index(b:cfi_cache_list, a:ctx)
+        if found && b:cfi_cache_list[index].version is s:get_current_version()
+            return b:cfi_cache_list[index]
+        endif
+    endif
+    return a:else
+endfunction "}}}
+
+function! s:save_cache(ctx, val) "{{{
+    call s:save_cache_list(a:ctx, a:val)
+    if !exists('b:cfi_last_result')
+        let b:cfi_last_result = {}
+    endif
+    let key = join([s:get_current_version(), a:ctx.lnum, a:ctx.col], '|')
+    let b:cfi_last_result = {key : a:val}
+endfunction "}}}
+
+function! s:save_cache_list(ctx, val) "{{{
+    if !exists('b:cfi_cache_list')
+        let b:cfi_cache_list = []
+    endif
+
+    " Search cache.
+    let [index, found] = s:bsearch_nearest_index(b:cfi_cache_list, a:ctx)
+    if found
+        " Update cache.
+        let b:cfi_cache_list[index] = a:val
+    else
+        " Save cache.
+        call insert(b:cfi_cache_list, a:val)
+    endif
+
+    " TODO: Get rid of old cache.
+    " if len(b:cfi_cache_list) ># 30
+    "   ...
+    " endif
+endfunction "}}}
+
+function! s:bsearch_nearest_index(list, ctx) "{{{
+    if empty(a:list)
+        return [0, 0]
+    endif
+    let [begin, end] = [0, len(a:list) - 1]
+    let found = 0
+    while 1
+        let middle = (begin + end) / 2
+        let ret = s:compare_pos_to_range(a:ctx, a:list[middle])
+        if ret is 0
+            let found = 1
+            break
+        elseif ret <# 0
+            let begin = middle
+        else
+            let end = middle
+        endif
+        if middle is (begin + end) / 2
+            break
+        endif
+    endwhile
+    return [middle, found]
+endfunction "}}}
+
+function! s:compare_pos_to_range(pos, range) "{{{
+    let [lnum, col] = [a:pos.lnum, a:pos.col]
+    let [begin_lnum, begin_col] = a:range.begin_pos
+    let [end_lnum, end_col] = a:range.end_pos
+    if lnum <# begin_lnum ||
+    \   (lnum is begin_lnum && col <# begin_col)
+        return -1
+    elseif lnum ># end_lnum ||
+    \   (lnum is end_lnum && col ># end_col)
+        return 1
+    else
+        return 0
+    endif
+endfunction "}}}
+
+function! s:pos_is_less_than(pos1, pos2) "{{{
+    let [lnum1, col1] = a:pos1
+    let [lnum2, col2] = a:pos2
+    return
+    \   lnum1 <# lnum2
+    \   || (lnum1 is lnum2
+    \       && col1 <# col2)
+endfunction "}}}
+
+function! s:error(msg) "{{{
+    call s:echomsg("ErrorMsg", a:msg)
+endfunction "}}}
+
+function! s:echomsg(hl, msg) "{{{
+    execute 'echohl' a:hl
+    try
+        echomsg a:msg
+    finally
+        echohl None
+    endtry
+endfunction "}}}
+
+
+
+" Restore 'cpoptions' {{{
+let &cpo = s:save_cpo
+" }}}

--- a/knowhow/vim/.vim/doc/cfi.txt
+++ b/knowhow/vim/.vim/doc/cfi.txt
@@ -1,0 +1,149 @@
+*cfi.txt*
+
+Author:
+  tyru <tyru.exe@gmail.com>
+Version: 0.0.5
+License:
+NEW BSD LICENSE {{{
+  Copyright (c) 2010, tyru
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+      * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+      * Neither the name of the tyru nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+}}}
+
+==============================================================================
+CONTENTS						*cfi-contents*
+
+Introduction		|cfi-introduction|
+Interface			|cfi-interface|
+  Functions			|cfi-functions|
+  Variables			|cfi-variables|
+    PHP				|cfi-lang-php|
+    JavaScript			|cfi-lang-javascript|
+Changelog			|cfi-changelog|
+Thanks				|cfi-thanks|
+
+
+==============================================================================
+INTRODUCTION						*cfi-introduction* {{{
+
+current-func-info shows current function's name to statusline, tabline,
+anywhere.
+|cfi#get_func_name()| to get function's name.
+
+}}}
+==============================================================================
+INTERFACE				*cfi-interface* {{{
+------------------------------------------------------------------------------
+FUNCTIONS					*cfi-functions* {{{
+
+
+cfi#load()				*cfi#load()*
+	Load "autoload/cfi.vim" and "plugin/cfi.vim".
+
+cfi#get_func_name([{filetype}])				*cfi#get_func_name()*
+	Returns function's name.
+	If {filetype} is omitted, current 'filetype' is used instead.
+	Include this expression to |'statusline'| or |'tabline'| and so on.
+
+cfi#format({fmt}, {default})			*cfi#format()*
+	Returns formatted string. >
+    let &statusline = '%{cfi#format("[%s()]", "no function")}'
+<	This returns "no function" if cfi#get_func_name() returns empty string.
+	Or returns "[func()]" if cfi#get_func_name() returns "func".
+
+cfi#create_finder({filetype})				*cfi#create_finder()*
+	Returns Dictionary of instance for finder.
+
+	To create finder, implement |s:finder.find()| or
+	implement |s:finder.get_func_name()|, |s:finder.find_begin()|,
+	|s:finder.find_end()|.
+
+	(TODO: Write more descriptions)
+
+	See ftplugin/*.vim for the details.
+
+cfi#supported_filetype({filetype})				*cfi#supported_filetype()*
+cfi#supported_filetypes({filetype})				*cfi#supported_filetypes()*
+	Return boolean value if {filetype} is supported.
+	If {filetype} is dot-separeted,
+	return true if all filetypes are supported.
+
+cfi#get_finder({filetype})					*cfi#get_finder()*
+	Return finder object for given filetype if it's supported,
+	or 0 if not
+
+}}}
+------------------------------------------------------------------------------
+VARIABLES					*cfi-variables* {{{
+
+g:cfi_disable					*g:cfi_disable*
+	If true, disable all features and ftplugins.
+
+g:loaded_cfi_ftplugin_{lang}	*g:loaded_cfi_ftplugin*
+	If true, disable the load of ftplugin/{lang}/cfi.vim
+
+
+PHP                                      *cfi-lang-php*
+------
+
+g:cfi_php_show_params			*g:cfi_php_show_params*
+							(Default: 0)
+	Include arguments to |cfi#get_func_name()|'s return value.
+
+
+JavaScript                                      *cfi-lang-javascript*
+-----
+
+g:cfi_javascript_show                   *g:cfi_javascript_show*
+
+	Configure the javascript function display. Include the keys you want
+	and set them to 0 to disable their display.
+	Defaults to showing everything.
+
+>
+  let g:cfi_javascript_show = {
+	\   'assignment': 0,
+	\   'variable_name': 0,
+	\   'function_type': 0,
+	\   'function_name': 0,
+	\   'function_arguments': 0,
+	\   'function_body': 0,
+	\ }
+<
+
+}}}
+}}}
+==============================================================================
+CHANGELOG						*cfi-changelog* {{{
+
+0.0.0:
+- Initial upload
+0.0.1:
+- Fix bug: couldn't get the name of last function in a file.
+0.0.2:
+- Implement cfi#format()
+- Implement Python support
+0.0.3:
+- Fix bug: Ruby ftplugin did not work.
+0.0.4:
+- Include PHP support. Thanks Chris Ruzin.
+0.0.5:
+- Fix the flickering of c ftplugin
+- Add variables g:cfi_disable, g:loaded_cfi_ftplugin_{lang}.
+
+}}}
+==============================================================================
+Thanks						*cfi-thanks* {{{
+
+- athom
+
+}}}
+==============================================================================
+vim:tw=78:fo=tcq2mM:ts=4:ft=help:norl:noet:fdm=marker:fen

--- a/knowhow/vim/.vim/ftplugin/bash/cfi.vim
+++ b/knowhow/vim/.vim/ftplugin/bash/cfi.vim
@@ -1,0 +1,5 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+runtime! ftplugin/sh/cfi.vim
+cfi#register_finder('bash', cfi#get_finder('sh'))

--- a/knowhow/vim/.vim/ftplugin/c/cfi.vim
+++ b/knowhow/vim/.vim/ftplugin/c/cfi.vim
@@ -1,0 +1,102 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+
+if get(g:, 'cfi_disable') || get(g:, 'loaded_cfi_ftplugin_c')
+    finish
+endif
+let g:loaded_cfi_ftplugin_c = 1
+
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+
+let s:FUNCTION_PATTERN = '\C'.'\(\w\+\)\s*('
+
+let s:finder = cfi#create_finder('c')
+
+function! s:finder.get_func_name() "{{{
+    let NONE = ''
+    if self.phase isnot 2 || !has_key(self.temp, 'funcname')
+        return NONE
+    endif
+    return self.temp.funcname
+endfunction "}}}
+
+function! s:finder.find_begin() "{{{
+    let NONE = []
+    let [orig_lnum, orig_col] = [line('.'), col('.')]
+
+    let vb = &vb
+    setlocal vb t_vb=
+    try
+        " Jump to function-like word, and check arguments, and block.
+        while 1
+            if search(s:FUNCTION_PATTERN, 'bW') == 0
+                return NONE
+            endif
+            " Function name when filetype=c has nothing about syntax info.
+            " (without this condition, if-statement is recognized as function)
+            if !empty(synstack(line('.'), col('.')))
+                continue
+            endif
+            let funcname = get(matchlist(getline('.'), s:FUNCTION_PATTERN), 1, '')
+            if funcname ==# ''
+                return NONE
+            endif
+            for [fn; args] in [
+            \   ['search', '(', 'W'],
+            \   ['searchpair', '(', '', ')'],
+            \]
+                if call(fn, args) == 0
+                    return NONE
+                endif
+            endfor
+            if join(getline('.', '$'), '')[col('.') :] =~# '^\s*;'
+                " Function declaration
+                return NONE
+            else
+                let self.temp.funcname = funcname
+                break
+            endif
+        endwhile
+    finally
+        let &vb = vb
+    endtry
+
+    if search('{') == 0
+        return NONE
+    endif
+    if line('.') == orig_lnum && col('.') == orig_col
+        return NONE
+    endif
+    return [line('.'), col('.')]
+endfunction "}}}
+
+function! s:finder.find_end() "{{{
+    let NONE = []
+    let [orig_lnum, orig_col] = [line('.'), col('.')]
+
+    let vb = &vb
+    setlocal vb t_vb=
+    keepjumps normal! ][
+    let &vb = vb
+
+    if line('.') == orig_lnum && col('.') == orig_col
+        return NONE
+    endif
+    if getline('.')[col('.')-1] !=# '}'
+        return NONE
+    endif
+    let self.is_ready = 1
+    return [line('.'), col('.')]
+endfunction "}}}
+
+call cfi#register_finder('c', s:finder)
+unlet s:finder
+
+
+
+let &cpo = s:save_cpo

--- a/knowhow/vim/.vim/ftplugin/elixir/cfi.vim
+++ b/knowhow/vim/.vim/ftplugin/elixir/cfi.vim
@@ -1,0 +1,38 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+if get(g:, 'cfi_disable') || get(g:, 'loaded_cfi_ftplugin_elixir')
+    finish
+endif
+let g:loaded_cfi_ftplugin_elixir = 1
+
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+
+let s:BEGIN_PATTERN = '\C'.'^\s*'.'def\>'.'\s\+'.'\('.'[^(]\+'.'\)'.'\%('.'\s*'.'('.'\=\)'
+
+let s:finder = cfi#create_finder('elixir')
+
+function! s:finder.find(ctx) "{{{
+    let NONE = ''
+
+    if search(s:BEGIN_PATTERN, 'bW') == 0
+        return NONE
+    endif
+
+    let m = matchlist(getline('.'), s:BEGIN_PATTERN)
+    if empty(m)
+        return NONE
+    endif
+
+    return m[1]
+endfunction "}}}
+
+call cfi#register_simple_finder('elixir', s:finder)
+unlet s:finder
+
+let &cpo = s:save_cpo
+

--- a/knowhow/vim/.vim/ftplugin/go/cfi.vim
+++ b/knowhow/vim/.vim/ftplugin/go/cfi.vim
@@ -1,0 +1,43 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+
+if get(g:, 'cfi_disable') || get(g:, 'loaded_cfi_ftplugin_go')
+    finish
+endif
+let g:loaded_cfi_ftplugin_go = 1
+
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+
+
+let s:BEGIN_PATTERN = '\C'.'^\s*'.'func\>'.'\s\+'.'\((\w\+\s\+[^)]\+)\s\+\)\='.'\('.'[^(]\+'.'\)'.'\%('.'\s*'.'('.'\=\)'
+
+let s:finder = cfi#create_finder('go')
+
+function! s:finder.find(ctx) "{{{
+    let NONE = ''
+
+    if search(s:BEGIN_PATTERN, 'bW') == 0
+        return NONE
+    endif
+
+    let m = matchlist(getline('.'), s:BEGIN_PATTERN)
+    if empty(m)
+        return NONE
+    endif
+
+    return m[1].m[2]
+endfunction "}}}
+
+call cfi#register_simple_finder('go', s:finder)
+unlet s:finder
+
+
+
+
+let &cpo = s:save_cpo
+

--- a/knowhow/vim/.vim/ftplugin/javascript/cfi.vim
+++ b/knowhow/vim/.vim/ftplugin/javascript/cfi.vim
@@ -1,0 +1,231 @@
+scriptencoding utf-8
+
+" ============================================================================
+" Bootstrap
+" ============================================================================
+
+if get(g:, 'cfi_disable') || get(g:, 'loaded_cfi_ftplugin_javascript')
+  finish
+endif
+let g:loaded_cfi_ftplugin_javascript = 1
+
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+" ============================================================================
+" Options
+" ============================================================================
+
+" Configure display verbosity
+" By default, show everything
+let s:show_defaults = {
+      \   'assignment': 1,
+      \   'variable_name': 1,
+      \   'function_type': 1,
+      \   'function_name': 1,
+      \   'function_arguments': 1,
+      \   'function_body': 1,
+      \ }
+if exists('g:cfi_javascript_show')
+  " Add any missing values, preserve the user settings
+  call extend(g:cfi_javascript_show, s:show_defaults, 'keep')
+else
+  let g:cfi_javascript_show = s:show_defaults
+endif
+
+" Deprecation warnings for the old style config
+" Remove it after a while (couple months, at least
+" "Now": 2016-03-13
+if exists('g:cfi_javascript_show_assignment')
+  echohl WarningMsg | echom 'CFI: g:cfi_javascript_show_assignment deprecated, use g:cfi_javascript_show' | echohl None
+endif
+
+" ============================================================================
+" Regexes
+" magic mode!
+" ============================================================================
+
+" variable: match nonblanks and no *. This is loose, don't want to write
+" complete js parser
+let s:VARIABLE_NAME       = '\([^[:blank:]*]\+\)'
+
+" function name: Match nonblanks, no parens or generator yield star
+let s:FUNCTION_NAME       = '\(\%([^[:blank:]()*]\)\+\)'
+
+" matches es6 classes and generator functions
+" @TODO es6 member function shorthand `func() {}`
+let s:FUNCTION_TYPE       = '\('
+      \.  'get\|set\|static\|function'
+      \.'\)'
+
+" (...)
+let s:FUNCTION_ARGUMENTS  = '\(' . '([^)]*)' . '\)'
+
+" ----------------------------------------------------------------------------
+" Composite regexes
+" ----------------------------------------------------------------------------
+
+" .\{-} will throw away var/let/const anything before variable name
+let s:VARIABLE = '\%('
+      \.  '.\{-}'
+      \.  s:VARIABLE_NAME
+      \.  '\s*='
+      \.'\)'
+
+let s:ANONYMOUS_FUNCTION = '\%('
+      \.  s:FUNCTION_TYPE
+      \.  '[[:blank:]*]\+'
+      \.  s:FUNCTION_ARGUMENTS
+      \.'\)'
+
+let s:NAMED_FUNCTION = '\%('
+      \.  s:FUNCTION_TYPE
+      \.  '[[:blank:]*]\+'
+      \.  s:FUNCTION_NAME
+      \.  '\s*'
+      \.  s:FUNCTION_ARGUMENTS
+      \.'\)'
+
+let s:ARROW_FUNCTION = ''
+      \.  '\%(' . s:FUNCTION_ARGUMENTS . '\s*=>\s*' . '\)'
+
+" Pattern that triggers parsing of matches
+" For the arrow function we also check that there is a function body (so we
+" don't start on arrow function with only return, e.g. `(arr) => arr.join('')`
+let s:BEGIN_PATTERN = '\C'
+      \. '\%(' . s:ANONYMOUS_FUNCTION
+      \.  '\|' . s:NAMED_FUNCTION
+      \.  '\|' . s:ARROW_FUNCTION . '\s*{'
+      \. '\)\{1}'
+
+" ============================================================================
+" Create cfi finder dictionary of functions
+" ============================================================================
+
+let s:finder = cfi#create_finder('javascript')
+
+" Matcher run on function start line if find_begin search found a starter
+" @return {String}
+function! s:finder.get_func_name() "{{{
+  if l:self.phase !=# 1
+    return ''
+  endif
+
+  let l:done = 0
+  let l:assignment = 'declaration'
+  let l:variable_name = ''        " '[var ][abc.]xyz =  '
+  let l:function_type = ''        " generator star
+  let l:function_name = ''        " string
+  let l:function_arguments = ''   " (arg, arg)
+  let l:function_body = ' { ... }'       " => { }
+
+  let l:declaration = getline('.')
+  let l:matcher = matchlist(getline('.'), s:VARIABLE)
+  if !empty(l:matcher)
+    let l:assignment = 'expression'
+    let l:variable_name = l:matcher[1] . ' = '
+
+    " we use l:declaration to match going forward so we only check against
+    " actual function part
+    let l:declaration = substitute(getline('.'), s:VARIABLE, '', '')
+  endif
+
+  " hmm... maybe return early instead of storing values?
+  " or use a map that returns a dict for a function that generates formatted
+  " return value?
+
+  let l:matcher = matchlist(l:declaration, s:NAMED_FUNCTION)
+  if !empty(l:matcher)
+    let l:assignment = 'named ' . l:assignment
+    let l:function_type = l:matcher[1]
+    let l:function_name = l:matcher[2]
+    let l:function_arguments = l:matcher[3]
+    let l:done = 1
+  endif
+
+  if !l:done
+    let l:matcher = matchlist(l:declaration, s:ANONYMOUS_FUNCTION)
+    if !empty(l:matcher)
+      let l:assignment = 'anon ' . l:assignment
+      let l:function_type = l:matcher[1]
+      let l:function_arguments = l:matcher[2]
+      let l:done = 2
+    endif
+  endif
+
+  if !l:done
+    let l:matcher = matchlist(l:declaration, s:ARROW_FUNCTION)
+    if !empty(l:matcher)
+      let l:assignment = 'arrow ' . l:assignment
+      let l:function_arguments = l:matcher[1]
+      let l:function_body = ' => { ... }'
+      let l:done = 3
+    endif
+  endif
+
+  if !l:done
+    return ''
+  endif
+
+  " trim extra spaces around `function  *   ` so it becomes `function* `
+  " this follows MDN style and eslint default for generator-star-spacing
+  let l:function_type = substitute(l:function_type,
+        \ '\(function\)\s*\(\*\)\=\s*',
+        \ '\1\2', '')
+
+  let l:assignment .= ': '
+  let l:function_type .= (!empty(l:function_type) ? ' ' : '')
+  " Use the setting dict to selectively show parts of the name
+  " Don't let the user break this, cycle through our dictionary for keys
+  let l:result = ''
+  for var in keys(s:show_defaults)
+    if g:cfi_javascript_show[var]
+      let l:result .= l:{var}
+    endif
+  endfor
+  return l:result
+endfunction "}}}
+
+" Find line where function starts
+" @return {List}
+function! s:finder.find_begin() "{{{
+  " loose function check, just look for `) {`
+  "if search(').*{', 'bW') == 0
+  if search(s:BEGIN_PATTERN, 'bW') == 0
+    return []
+  endif
+
+  let l:self.is_ready = 1
+  return [line('.'), col('.')]
+endfunction "}}}
+
+" Find line where function ends
+" @return {List}
+function! s:finder.find_end() "{{{
+  let l:self.is_ready = 0
+
+  if search('{', 'W') == 0
+    return []
+  endif
+
+  if searchpair('{', '', '}', 'W') == 0
+    return []
+  endif
+
+  return [line('.'), col('.')]
+endfunction "}}}
+
+" ============================================================================
+" Register
+" ============================================================================
+
+call cfi#register_finder('javascript', s:finder)
+unlet s:finder
+
+" ============================================================================
+" Unbootstrap
+" ============================================================================
+
+let &cpo = s:save_cpo

--- a/knowhow/vim/.vim/ftplugin/perl/cfi.vim
+++ b/knowhow/vim/.vim/ftplugin/perl/cfi.vim
@@ -1,0 +1,59 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+
+if get(g:, 'cfi_disable') || get(g:, 'loaded_cfi_ftplugin_perl')
+    finish
+endif
+let g:loaded_cfi_ftplugin_perl = 1
+
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+
+
+let s:PROTOTYPE_DEF = '([^()]*)'
+let s:CODE_ATTR = '\%('.'\s*:\s*\%(.\+\)'.'\)\='
+let s:BEGIN_PATTERN = '\C'.'^\s*'.'sub\>'.'\s\+'.'\(\w\+\)'.'\%('.'\s*'.s:PROTOTYPE_DEF.'\)\='.s:CODE_ATTR
+let s:BLOCK_FIRST_BRACE = '[[:space:][:return:]]*'.'\zs{'
+
+let s:finder = cfi#create_finder('perl')
+
+function! s:finder.get_func_name() "{{{
+    let NONE = ''
+    if self.phase !=# 1
+        return NONE
+    endif
+    let m = matchlist(getline('.'), s:BEGIN_PATTERN)
+    if empty(m)
+        return NONE
+    endif
+    return m[1]
+endfunction "}}}
+
+function! s:finder.find_begin() "{{{
+    let NONE = []
+    if search(s:BEGIN_PATTERN.s:BLOCK_FIRST_BRACE, 'bW') == 0
+        return NONE
+    endif
+    let self.is_ready = 1
+    return [line('.'), col('.')]
+endfunction "}}}
+
+function! s:finder.find_end() "{{{
+    let NONE = []
+    if searchpair('{', '', '}', 'W') == 0
+        return NONE
+    endif
+    return [line('.'), col('.')]
+endfunction "}}}
+
+call cfi#register_finder('perl', s:finder)
+unlet s:finder
+
+
+
+
+let &cpo = s:save_cpo

--- a/knowhow/vim/.vim/ftplugin/php/cfi.vim
+++ b/knowhow/vim/.vim/ftplugin/php/cfi.vim
@@ -1,0 +1,78 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+
+if get(g:, 'cfi_disable') || get(g:, 'loaded_cfi_ftplugin_php')
+    finish
+endif
+let g:loaded_cfi_ftplugin_php = 1
+
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+
+
+if !exists('g:cfi_php_show_params')
+    let g:cfi_php_show_params = 0
+endif
+
+
+
+if g:cfi_php_show_params
+    let s:BEGIN_PATTERN = '\C'.'^\s*'.'\%(public\s\+\|static\s\+\|abstract\s\+\|protected\s\+\|private\s\+\)\{-}'.'function\>'.'\s\+'.'\('.'.*$'.'\)'
+else
+    let s:BEGIN_PATTERN = '\C'.'^\s*'.'\%(public\s\+\|static\s\+\|abstract\s\+\|protected\s\+\|private\s\+\)\{-}'.'function\>'.'\s\+'.'\('.'[^(]\+'.'\)'.'\%('.'\s*'.'('.'\=\)'
+endif
+
+let s:finder = cfi#create_finder('php')
+
+function! s:finder.get_func_name() "{{{
+    let NONE = ''
+
+    if self.phase !=# 1
+        return NONE
+    endif
+
+    let m = matchlist(getline('.'), s:BEGIN_PATTERN)
+    if empty(m)
+        return NONE
+    endif
+
+    return m[1]
+endfunction "}}}
+
+function! s:finder.find_begin() "{{{
+    let NONE = []
+
+    if search(s:BEGIN_PATTERN, 'bW') == 0
+        return NONE
+    endif
+
+    let self.is_ready = 1
+    return [line('.'), col('.')]
+endfunction "}}}
+
+function! s:finder.find_end() "{{{
+    let NONE = []
+    let self.is_ready = 0
+
+    if search('{', 'W') == 0
+        return NONE
+    endif
+
+    if searchpair('{', '', '}', 'W') == 0
+        return NONE
+    endif
+
+    return [line('.'), col('.')]
+endfunction "}}}
+
+call cfi#register_finder('php', s:finder)
+unlet s:finder
+
+
+
+
+let &cpo = s:save_cpo

--- a/knowhow/vim/.vim/ftplugin/python/cfi.vim
+++ b/knowhow/vim/.vim/ftplugin/python/cfi.vim
@@ -1,0 +1,52 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+
+if get(g:, 'cfi_disable') || get(g:, 'loaded_cfi_ftplugin_python')
+    finish
+endif
+let g:loaded_cfi_ftplugin_python = 1
+
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+
+
+let s:BEGIN_PATTERN = '\C'.'^\s*'.'\(def\|class\|async def\)\>'.'\s\+'.'\(\w\+\)'
+
+let s:finder = cfi#create_finder('python')
+
+function! s:finder.find(ctx) "{{{
+    let save_view = winsaveview()
+
+    let ini_pos = prevnonblank('.')
+    let indent_num = indent(ini_pos)
+    let namespace = []
+    while 1
+        let decl_pos = search(s:BEGIN_PATTERN, 'bW')
+        if decl_pos == 0
+            break
+        endif
+
+        let decl_indent_num = indent(prevnonblank('.'))
+        if decl_indent_num < indent_num || (len(namespace) == 0 && ini_pos == decl_pos)
+            let m = matchlist(getline(decl_pos), s:BEGIN_PATTERN)
+            let indent_num = decl_indent_num
+            call insert(namespace, m[2])
+        endif
+    endwhile
+
+    call winrestview(save_view)
+
+    return join(namespace, '.')
+endfunction "}}}
+
+call cfi#register_simple_finder('python', s:finder)
+unlet s:finder
+
+
+
+
+let &cpo = s:save_cpo

--- a/knowhow/vim/.vim/ftplugin/ruby/cfi.vim
+++ b/knowhow/vim/.vim/ftplugin/ruby/cfi.vim
@@ -1,0 +1,42 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+
+if get(g:, 'cfi_disable') || get(g:, 'loaded_cfi_ftplugin_ruby')
+    finish
+endif
+let g:loaded_cfi_ftplugin_ruby = 1
+
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+
+
+let s:BEGIN_PATTERN = '\C'.'^\s*'.'def\>'.'\s\+'.'\('.'[^(]\+'.'\)'.'\%('.'\s*'.'('.'\=\)'
+
+let s:finder = cfi#create_finder('ruby')
+
+function! s:finder.find(ctx) "{{{
+    let NONE = ''
+
+    if search(s:BEGIN_PATTERN, 'bW') == 0
+        return NONE
+    endif
+
+    let m = matchlist(getline('.'), s:BEGIN_PATTERN)
+    if empty(m)
+        return NONE
+    endif
+
+    return m[1]
+endfunction "}}}
+
+call cfi#register_simple_finder('ruby', s:finder)
+unlet s:finder
+
+
+
+
+let &cpo = s:save_cpo

--- a/knowhow/vim/.vim/ftplugin/sh/cfi.vim
+++ b/knowhow/vim/.vim/ftplugin/sh/cfi.vim
@@ -1,0 +1,39 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+
+if get(g:, 'cfi_disable') || get(g:, 'loaded_cfi_ftplugin_sh')
+    finish
+endif
+let g:loaded_cfi_ftplugin_sh = 1
+
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+let s:BEGIN_PATTERN = '\C'.'^\s*'.'\%(function\s\+\)\?'.'\(\S\+\)'.'\s*()'
+let s:finder = cfi#create_finder('sh')
+
+function! s:finder.find(ctx) "{{{
+    let NONE = ''
+
+    if search(s:BEGIN_PATTERN, 'bW') == 0
+        return NONE
+    endif
+
+    let m = matchlist(getline('.'), s:BEGIN_PATTERN)
+    if empty(m)
+        return NONE
+    endif
+
+    return m[1]
+endfunction "}}}
+
+call cfi#register_simple_finder('sh', s:finder)
+unlet s:finder
+
+
+
+
+let &cpo = s:save_cpo

--- a/knowhow/vim/.vim/ftplugin/sql/cfi.vim
+++ b/knowhow/vim/.vim/ftplugin/sql/cfi.vim
@@ -1,0 +1,36 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+if get(g:, 'cfi_disable') || get(g:, 'loaded_cfi_ftplugin_sql')
+    finish
+endif
+let g:loaded_cfi_ftplugin_sql = 1
+
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+let s:BEGIN_PATTERN = '\c'.'^\s*'.'function\>'.'\s*'.'\(\w\+\)'.'\s*'.'('
+
+let s:finder = cfi#create_finder('sql')
+
+function! s:finder.find(ctx) "{{{
+    let NONE = ''
+
+    if search(s:BEGIN_PATTERN, 'bW') == 0
+        return NONE
+    endif
+
+    let m = matchlist(getline('.'), s:BEGIN_PATTERN)
+    if empty(m)
+        return NONE
+    endif
+
+    return m[1]
+endfunction "}}}
+
+call cfi#register_simple_finder('sql', s:finder)
+unlet s:finder
+
+let &cpo = s:save_cpo

--- a/knowhow/vim/.vim/ftplugin/vim/cfi.vim
+++ b/knowhow/vim/.vim/ftplugin/vim/cfi.vim
@@ -1,0 +1,60 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+
+if get(g:, 'cfi_disable') || get(g:, 'loaded_cfi_ftplugin_vim')
+    finish
+endif
+let g:loaded_cfi_ftplugin_vim = 1
+
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+
+
+let s:BEGIN_PATTERN = '\C'.'^\s*'.'fu\%[nction]\>'.'!\='.'\s\+'.'\([^(]\+\)'.'('
+let s:END_PATTERN   = '\C'.'^\s*'.'endf\%[unction]\>'
+
+
+
+let s:finder = cfi#create_finder('vim')
+
+function! s:finder.get_func_name() "{{{
+    let NONE = ''
+    if self.phase !=# 1
+        return NONE
+    endif
+    let m = matchlist(getline('.'), s:BEGIN_PATTERN)
+    if empty(m)
+        return NONE
+    endif
+    return m[1]
+endfunction "}}}
+
+function! s:finder.find_begin() "{{{
+    let NONE = 0
+    let begin_lnum = search(s:BEGIN_PATTERN, 'bW')
+    if begin_lnum == 0
+        return NONE
+    endif
+    let self.is_ready = 1
+    return [line('.'), col('.')]
+endfunction "}}}
+
+function! s:finder.find_end() "{{{
+    let NONE = []
+    if searchpair(s:BEGIN_PATTERN, '', s:END_PATTERN, 'W') == 0
+        return NONE
+    endif
+    return [line('.'), col('.')]
+endfunction "}}}
+
+call cfi#register_finder('vim', s:finder)
+unlet s:finder
+
+
+
+
+let &cpo = s:save_cpo

--- a/knowhow/vim/.vim/ftplugin/zsh/cfi.vim
+++ b/knowhow/vim/.vim/ftplugin/zsh/cfi.vim
@@ -1,0 +1,5 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+runtime! ftplugin/sh/cfi.vim
+call cfi#register_simple_finder('zsh', cfi#get_finder('sh'))

--- a/knowhow/vim/.vim/plugin/cfi.vim
+++ b/knowhow/vim/.vim/plugin/cfi.vim
@@ -1,0 +1,22 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+" Load Once {{{
+if (exists('g:loaded_cfi') && g:loaded_cfi) || &cp
+    finish
+endif
+let g:loaded_cfi = 1
+" }}}
+" Saving 'cpoptions' {{{
+let s:save_cpo = &cpo
+set cpo&vim
+" }}}
+
+let g:cfi_disable = exists('g:cfi_disable') && g:cfi_disable isnot 0
+command! CfiEnable  let g:cfi_disable = !!0
+command! CfiDisable let g:cfi_disable = !!1
+
+
+" Restore 'cpoptions' {{{
+let &cpo = s:save_cpo
+" }}}

--- a/knowhow/vim/.vim/plugin/gtags.vim
+++ b/knowhow/vim/.vim/plugin/gtags.vim
@@ -1,0 +1,565 @@
+" File: gtags.vim
+" Author: Tama Communications Corporation
+" Version: 0.6.8
+" Last Modified: Nov 9, 2015
+"
+" Copyright and license
+" ---------------------
+" Copyright (c) 2004, 2008, 2010, 2011, 2012, 2014, 2015
+" Tama Communications Corporation
+"
+" This file is part of GNU GLOBAL.
+"
+" This program is free software: you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation, either version 3 of the License, or
+" (at your option) any later version.
+" 
+" This program is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+" 
+" You should have received a copy of the GNU General Public License
+" along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"
+" Overview
+" --------
+" The gtags.vim plug-in script integrates the GNU GLOBAL source code tag system
+" with Vim. About the details, see http://www.gnu.org/software/global/.
+"
+" Installation
+" ------------
+" Drop the file in your plug-in directory or source it from your vimrc.
+" To use this script, you need GLOBAL-6.0 or later installed in your machine.
+"
+" Usage
+" -----
+" First of all, you must execute gtags(1) at the root of source directory
+" to make tag files. Assuming that your source directory is '/var/src',
+" it is necessary to execute the following commands.
+"
+"	$ cd /var/src
+"	$ gtags
+"
+" And you will find three tag files in the directory.
+"
+"	$ ls G*
+"	GPATH	GRTAGS	GTAGS
+"
+" General form of Gtags command is as follows:
+"
+"	:Gtags [option] pattern
+"
+" You can use all options of global(1) except for the -c, -p, -u and
+" all long name options. They are sent to global(1) as is.
+"
+" To go to 'func', you can say
+"
+"       :Gtags func
+"
+" Input completion is available. If you forgot the name of a function
+" but recall only some characters of the head, please input them and
+" press <TAB> key.
+"
+"       :Gtags fu<TAB>
+"       :Gtags func			<- Vim will append 'nc'.
+"
+" If you omitted an argument, vim ask it as follow:
+"
+"       Gtags for pattern: <current token>
+"
+" Inputting 'main' to the prompt, vim executes `global -x main',
+" parse the output, list located objects in the quickfix window
+" and load the first entry. The quickfix window shows like this:
+"
+"      gozilla/gozilla.c|200| main(int argc, char **argv)
+"      gtags-cscope/gtags-cscope.c|124| main(int argc, char **argv)
+"      gtags-parser/asm_scan.c|2056| int main()
+"      gtags-parser/gctags.c|157| main(int argc, char **argv)
+"      gtags-parser/php.c|2116| int main()
+"      gtags/gtags.c|152| main(int argc, char **argv)
+"      [Quickfix List]
+"
+" You can go to any entry using quickfix command.
+"
+" :cn'
+"      go to the next line.
+"
+" :cp'
+"      go to the previous line.
+"
+" :ccN'
+"      go to the Nth line.
+"
+" :cl'
+"      list all lines.
+"
+" You can see a help for quickfix like this:
+"
+"          :h quickfix
+"
+" You can use POSIX regular expression too. It requires more execution time though.
+"
+"       :Gtags ^[sg]et_
+"
+" It will match to both of 'set_value' and 'get_value'.
+"
+" To go to the referenced point of 'func', add -r option.
+"
+"       :Gtags -r func
+"
+" To go to any symbols which are not defined in GTAGS, try this.
+"
+"       :Gtags -s func
+"
+" To go to any string other than symbol, try this.
+"
+"       :Gtags -g ^[sg]et_
+"
+" This command accomplishes the same function as grep(1) but is more convenient
+" because it retrieves an entire directory structure.
+"
+" To get list of objects in a file 'main.c', use -f command.
+"
+"       :Gtags -f main.c
+"
+" If you are editing `main.c' itself, you can use '%' instead.
+"
+"       :Gtags -f %
+"
+" You can get a list of files whose path include specified pattern.
+" For example:
+"
+"       :Gtags -P /vm/			<- all files under 'vm' directory.
+"       :Gtags -P \.h$			<- all include files.
+"	:Gtags -P init			<- all paths includes 'init'
+"
+" If you omitted an argument and input only <ENTER> key to the prompt,
+" vim shows list of all files in the project.
+"
+" Since all short options are sent to global(1) as is, you can 
+" use the -i, -o, -O, and so on.
+" 
+" For example, if you want to ignore case distinctions in pattern.
+"
+"       :Gtags -gi paTtern
+"
+" It will match to both of 'PATTERN' and 'pattern'.
+"
+" If you want to search a pattern which starts with a hyphen like '-C'
+" then you can use the -e option like grep(1).
+"
+"	:Gtags -ge -C
+"
+" By default, Gtags command search only in source files. If you want to
+" search in both source files and text files, or only in text files then
+"
+"	:Gtags -go pattern		# both source and text
+"	:Gtags -gO pattern		# only text file
+"
+" See global(1) for other options.
+"
+" The Gtagsa (Gtags + append) command is almost the same as Gtags command.
+" But it differs from Gtags in that it adds the results to the present list.
+" If you want to get the union of ':Gtags -d foo' and ':Gtags -r foo' then
+" you can invoke the following commands:
+"
+"       :Gtags  -d foo
+"       :Gtagsa -r foo
+"
+" The GtagsCursor command brings you to the definition or reference of
+" the current token. If it is a definition, you are taken to the references.
+" If it is a reference, you are taken to the definitions.
+"
+"       :GtagsCursor
+"
+" If you have the hypertext generated by htags(1) then you can display
+" the same place on mozilla browser. Let's load mozilla and try this:
+"
+"       :Gozilla
+"
+" If you want to load vim with all main()s then following command line is useful.
+"
+"	% vim '+Gtags main'
+"
+" Also see the chapter of 'vim editor' of the on-line manual of GLOBAL.
+"
+"	% info global
+"
+" The following custom variables are available.
+"
+" Gtags_VerticalWindow    open windows vitically
+" Gtags_Auto_Map          use a suggested key-mapping
+" Gtags_Auto_Update       keep tag files up-to-date automatically
+" Gtags_No_Auto_Jump      don't jump to the first tag at the time of search
+" Gtags_Close_When_Single close quickfix windows in case of single tag
+"
+" You can use the variables like follows:
+"
+"	[$HOME/.vimrc]
+"	let Gtags_Auto_Map = 1
+"
+" If you want to use the tag stack, please use gtags-cscope.vim.
+" You can use the plug-in together with this script.
+"
+if exists("loaded_gtags")
+    finish
+endif
+
+"
+" global command name
+"
+let s:global_command = $GTAGSGLOBAL
+if s:global_command == ''
+        let s:global_command = "global"
+endif
+" Open the Gtags output window.  Set this variable to zero, to not open
+" the Gtags output window by default.  You can open it manually by using
+" the :cwindow command.
+" (This code was derived from 'grep.vim'.)
+if !exists("g:Gtags_OpenQuickfixWindow")
+    let g:Gtags_OpenQuickfixWindow = 1
+endif
+
+if !exists("g:Gtags_VerticalWindow")
+    let g:Gtags_VerticalWindow = 0
+endif
+
+if !exists("g:Gtags_Auto_Map")
+    let g:Gtags_Auto_Map = 0
+endif
+
+if !exists("g:Gtags_Auto_Update")
+    let g:Gtags_Auto_Update = 0
+endif
+
+" 'Dont_Jump_Automatically' is deprecated.
+if !exists("g:Gtags_No_Auto_Jump")
+    if !exists("g:Dont_Jump_Automatically")
+	let g:Gtags_No_Auto_Jump = 0
+    else
+	let g:Gtags_No_Auto_Jump = g:Dont_Jump_Automatically
+    endif
+endif
+
+if !exists("g:Gtags_Close_When_Single")
+    let g:Gtags_Close_When_Single = 0
+endif
+
+" -- ctags-x format 
+" let Gtags_Result = "ctags-x"
+" let Gtags_Efm = "%*\\S%*\\s%l%\\s%f%\\s%m"
+"
+" -- ctags format 
+" let Gtags_Result = "ctags"
+" let Gtags_Efm = "%m\t%f\t%l"
+"
+" Gtags_Use_Tags_Format is obsoleted.
+if exists("g:Gtags_Use_Tags_Format")
+    let g:Gtags_Result = "ctags"
+    let g:Gtags_Efm = "%m\t%f\t%l"
+endif
+if !exists("g:Gtags_Result")
+    let g:Gtags_Result = "ctags-mod"
+endif
+if !exists("g:Gtags_Efm")
+    let g:Gtags_Efm = "%f\t%l\t%m"
+endif
+" Character to use to quote patterns and file names before passing to global.
+" (This code was drived from 'grep.vim'.)
+if !exists("g:Gtags_Shell_Quote_Char")
+    if has("win32") || has("win16") || has("win95")
+        let g:Gtags_Shell_Quote_Char = '"'
+    else
+        let g:Gtags_Shell_Quote_Char = "'"
+    endif
+endif
+if !exists("g:Gtags_Single_Quote_Char")
+    if has("win32") || has("win16") || has("win95")
+        let g:Gtags_Single_Quote_Char = "'"
+        let g:Gtags_Double_Quote_Char = '\"'
+    else
+        let s:sq = "'"
+        let s:dq = '"'
+        let g:Gtags_Single_Quote_Char = s:sq . s:dq . s:sq . s:dq . s:sq
+        let g:Gtags_Double_Quote_Char = '"'
+    endif
+endif
+
+"
+" Display error message.
+"
+function! s:Error(msg)
+    echohl WarningMsg |
+           \ echomsg 'Error: ' . a:msg |
+           \ echohl None
+endfunction
+"
+" Extract pattern or option string.
+"
+function! s:Extract(line, target)
+    let l:option = ''
+    let l:pattern = ''
+    let l:force_pattern = 0
+    let l:length = strlen(a:line)
+    let l:i = 0
+
+    " skip command name.
+    if a:line =~# '^Gtags'
+        let l:i = 5
+    endif
+    while l:i < l:length && a:line[l:i] == ' '
+       let l:i = l:i + 1
+    endwhile 
+    while l:i < l:length
+        if a:line[l:i] == "-" && l:force_pattern == 0
+            let l:i = l:i + 1
+            " Ignore long name option like --help.
+            if l:i < l:length && a:line[l:i] == '-'
+                while l:i < l:length && a:line[l:i] != ' '
+                   let l:i = l:i + 1
+                endwhile 
+            else
+                while l:i < l:length && a:line[l:i] != ' '
+                    let l:c = a:line[l:i]
+                    let l:option = l:option . l:c
+                    let l:i = l:i + 1
+                endwhile 
+                if l:c ==# 'e'
+                    let l:force_pattern = 1
+                endif
+            endif
+        else
+            let l:pattern = ''
+            " allow pattern includes blanks.
+            while l:i < l:length
+                 if a:line[l:i] == "'"
+                     let l:pattern = l:pattern . g:Gtags_Single_Quote_Char
+                 elseif a:line[l:i] == '"'
+                     let l:pattern = l:pattern . g:Gtags_Double_Quote_Char
+                 else
+                     let l:pattern = l:pattern . a:line[l:i]
+                 endif
+                let l:i = l:i + 1
+            endwhile 
+            if a:target == 'pattern'
+                return l:pattern
+            endif
+        endif
+        " Skip blanks.
+        while l:i < l:length && a:line[l:i] == ' '
+               let l:i = l:i + 1
+        endwhile 
+    endwhile 
+    if a:target == 'option'
+        return l:option
+    endif
+    return ''
+endfunction
+
+"
+" Trim options to avoid errors.
+"
+function! s:TrimOption(option)
+    let l:option = ''
+    let l:length = strlen(a:option)
+    let l:i = 0
+
+    while l:i < l:length
+        let l:c = a:option[l:i]
+        if l:c !~# '[cenpquv]'
+            let l:option = l:option . l:c
+        endif
+        let l:i = l:i + 1
+    endwhile
+    return l:option
+endfunction
+
+"
+" Execute global and load the result into quickfix window.
+"
+function! s:ExecLoad(option, long_option, pattern, flags)
+    " Execute global(1) command and write the result to a temporary file.
+    let l:isfile = 0
+    let l:option = ''
+    let l:result = ''
+
+    if a:option =~# 'f'
+        let l:isfile = 1
+        if filereadable(a:pattern) == 0
+            call s:Error('File ' . a:pattern . ' not found.')
+            return
+        endif
+    endif
+    if a:long_option != ''
+        let l:option = a:long_option . ' '
+    endif
+    let l:option = l:option . '--result=' . g:Gtags_Result . ' -q'
+    let l:option = l:option . s:TrimOption(a:option)
+    if l:isfile == 1
+        let l:cmd = s:global_command . ' ' . l:option . ' ' . g:Gtags_Shell_Quote_Char . a:pattern . g:Gtags_Shell_Quote_Char
+    else
+        let l:cmd = s:global_command . ' ' . l:option . 'e ' . g:Gtags_Shell_Quote_Char . a:pattern . g:Gtags_Shell_Quote_Char 
+    endif
+
+    let l:result = system(l:cmd)
+    if v:shell_error != 0
+        if v:shell_error != 0
+            if v:shell_error == 2
+                call s:Error('invalid arguments. please use the latest GLOBAL.')
+            elseif v:shell_error == 3
+                call s:Error('GTAGS not found.')
+            else
+                call s:Error('global command failed. command line: ' . l:cmd)
+            endif
+        endif
+        return
+    endif
+    if l:result == '' 
+        if l:option =~# 'f'
+            call s:Error('Tag not found in ' . a:pattern . '.')
+        elseif l:option =~# 'P'
+            call s:Error('Path which matches to ' . a:pattern . ' not found.')
+        elseif l:option =~# 'g'
+            call s:Error('Line which matches to ' . a:pattern . ' not found.')
+        else
+            call s:Error('Tag which matches to ' . g:Gtags_Shell_Quote_Char . a:pattern . g:Gtags_Shell_Quote_Char . ' not found.')
+        endif
+        return
+    endif
+
+    " Open the quickfix window
+    if g:Gtags_OpenQuickfixWindow == 1
+	let l:open = 1
+        if g:Gtags_Close_When_Single == 1
+	    let l:open = 0
+	    let l:idx = stridx(l:result, "\n")
+	    if l:idx > 0 && stridx(l:result, "\n", l:idx + 1) > 0
+		let l:open = 1
+	    endif
+	endif
+	if l:open == 0
+	    cclose
+        elseif g:Gtags_VerticalWindow == 1
+            topleft vertical copen
+        else
+            botright copen
+        endif
+    endif
+    " Parse the output of 'global -x or -t' and show in the quickfix window.
+    let l:efm_org = &efm
+    let &efm = g:Gtags_Efm
+    if a:flags =~# 'a'
+        cadde l:result		" append mode
+    elseif g:Gtags_No_Auto_Jump == 1
+        cgete l:result		" does not jump
+    else
+        cexpr! l:result		" jump
+    endif
+    let &efm = l:efm_org
+endfunction
+
+"
+" RunGlobal()
+"
+function! s:RunGlobal(line, flags)
+    let l:pattern = s:Extract(a:line, 'pattern')
+
+    if l:pattern == '%'
+        let l:pattern = expand('%')
+    elseif l:pattern == '#'
+        let l:pattern = expand('#')
+    endif
+    let l:option = s:Extract(a:line, 'option')
+    " If no pattern supplied then get it from user.
+    if l:pattern == ''
+        let s:option = l:option
+        if l:option =~# 'f'
+            let l:line = input("Gtags for file: ", expand('%'), 'file')
+        else
+            let l:line = input("Gtags for pattern: ", expand('<cword>'), 'custom,GtagsCandidateCore')
+        endif
+        let l:pattern = s:Extract(l:line, 'pattern')
+        if l:pattern == ''
+            call s:Error('Pattern not specified.')
+            return
+        endif
+    endif
+    call s:ExecLoad(l:option, '', l:pattern, a:flags)
+endfunction
+
+"
+" Execute RunGlobal() depending on the current position.
+"
+function! s:GtagsCursor()
+    let l:pattern = expand("<cword>")
+    let l:option = "--from-here=\"" . line('.') . ":" . expand("%") . "\""
+    call s:ExecLoad('', l:option, l:pattern, '')
+endfunction
+
+"
+" Show the current position on mozilla.
+" (You need to execute htags(1) in your source directory.)
+"
+function! s:Gozilla()
+    let l:lineno = line('.')
+    let l:filename = expand("%")
+    let l:result = system('gozilla +' . l:lineno . ' ' . l:filename)
+endfunction
+"
+" Auto update of tag files using incremental update facility.
+"
+function! s:GtagsAutoUpdate()
+    let l:result = system(s:global_command . " -u --single-update=\"" . expand("%") . "\"")
+endfunction
+
+"
+" Custom completion.
+"
+function! GtagsCandidate(lead, line, pos)
+    let s:option = s:Extract(a:line, 'option')
+    return GtagsCandidateCore(a:lead, a:line, a:pos)
+endfunction
+
+function! GtagsCandidateCore(lead, line, pos)
+    if s:option ==# 'g'
+        return ''
+    elseif s:option ==# 'f'
+        if isdirectory(a:lead)
+            if a:lead =~ '/$'
+                let l:pattern = a:lead . '*'
+            else
+                let l:pattern = a:lead . '/*'
+            endif
+        else
+            let l:pattern = a:lead . '*'
+        endif
+        return glob(l:pattern)
+    else 
+        return system(s:global_command . ' ' . '-c' . s:option . ' ' . a:lead)
+    endif
+endfunction
+
+" Define the set of Gtags commands
+command! -nargs=* -complete=custom,GtagsCandidate Gtags call s:RunGlobal(<q-args>, '')
+command! -nargs=* -complete=custom,GtagsCandidate Gtagsa call s:RunGlobal(<q-args>, 'a')
+command! -nargs=0 GtagsCursor call s:GtagsCursor()
+command! -nargs=0 Gozilla call s:Gozilla()
+command! -nargs=0 GtagsUpdate call s:GtagsAutoUpdate()
+if g:Gtags_Auto_Update == 1
+	:autocmd! BufWritePost * call s:GtagsAutoUpdate()
+endif
+" Suggested map:
+if g:Gtags_Auto_Map == 1
+	:nmap <F2> :copen<CR>
+	:nmap <F4> :cclose<CR>
+	:nmap <F5> :Gtags<SPACE>
+	:nmap <F6> :Gtags -f %<CR>
+	:nmap <F7> :GtagsCursor<CR>
+	:nmap <F8> :Gozilla<CR>
+	:nmap <C-n> :cn<CR>
+	:nmap <C-p> :cp<CR>
+	:nmap <C-\><C-]> :GtagsCursor<CR>
+endif
+let loaded_gtags = 1

--- a/knowhow/vim/.vimrc
+++ b/knowhow/vim/.vimrc
@@ -1,6 +1,16 @@
 "基本設定
-"文字コードをUFT-8に設定
+"文字コードをutf-8に設定して保存する
 set fenc=utf-8
+"vimの内部文字コードをutf-8にエンコードする
+set encoding=utf-8
+"書き込み時の文字コードを指定する
+set fileencoding=utf-8
+"読み込み時の文字コードを指定する、左から順番に成功した文字コードになる
+set fileencodings=iso-2022-jp,euc-jp,sjis,utf-8
+"開いたソースファイルの改行コードの自動認識
+set fileformats=unix,dos,mac
+"ソースファイルの改行コードを指定する
+setl ff=unix
 "バックアップファイルを作らない
 set nobackup
 "スワップファイルを作らない
@@ -30,7 +40,7 @@ set wildmode=list:longest
 "シンタックスハイライトの有効化
 syntax on
 "カラースキーマ設定
-colorscheme elflord
+colorscheme morning
 "Tab文字を半角スペースにする
 set expandtab
 "行頭以外のTab文字の表示幅（スペースいくつ分）
@@ -42,7 +52,7 @@ set backspace=indent,eol,start
 "ヤンクした内容を別のウィンドウにペーストできるようにする
 set clipboard=unnamed,autoselect
 "閲覧中のファイルのパスを表示
-set statusline+=%F
+set statusline+=%f
 
 "入力補完
 "大括弧の入力補完
@@ -56,23 +66,49 @@ inoremap " ""<LEFT>
 inoremap ' ''<LEFT>
 
 "tab設定
-nnoremap t :<C-u>tabnew<space>
-nnoremap < gt
-nnoremap > gT
+nnoremap . gt
+nnoremap , gT
 
 "検索の設定
 "検索結果のハイライト
 set hlsearch
-"ハイライト解除
-nnoremap r :<C-u>noh<CR>
+"文字列のハイライト
+nnoremap * *N
 
 "ctagsの設定
 "vim tagを再帰的に検索する
 set tags+=tags;
 
 "gtagsの設定
-map <C-g> :Gtags
-map <C-h> :Gtags -f %<CR>
-map <C-j> :GtagsCursor<CR>
-map <C-n> :cn<CR>
-map <C-p> :cp<CR>
+"grep検索
+nnoremap <C-g> :tab sp<CR> :Gtags -g<space>
+"カーソル位置の関数へジャンプ
+nnoremap <C-j> :tab sp<CR> :GtagsCursor<CR>
+"関数の定義元(define)へタグジャンプ
+nnoremap <C-d> :tab sp<CR> :<C-u>exe('Gtags '.expand('<cword>'))<CR>
+"関数の参照元(reference)へジャンプ
+nnoremap <C-r> :tab sp<CR> :<C-u>exe('Gtags -r '.expand('<cword>'))<CR>
+"開いているファイルに定義されている関数一覧を表示
+nnoremap <C-h> :Gtags -f %<CR>
+"次の検索結果へジャンプする
+nnoremap <C-n> :cn<CR>
+"前の検索結果にジャンプする
+nnoremap <C-p> :cp<CR>
+
+"Quickfixの設定
+"Quickfixも一緒に閉じるようにする
+augroup QfAutoCommands
+  autocmd!
+
+  " Auto-close quickfix window
+  autocmd WinEnter * if (winnr('$') == 1) && (getbufvar(winbufnr(0), '&buftype')) == 'quickfix' | quit | endif
+augroup END
+
+"current-func-info.vimの設定
+let &statusline .= ' [%{cfi#format("%s", "")}]'
+
+"コンパイルスイッチ用の設定
+"マクロが定義されていて、かつ値が0orFALSEのもの
+autocmd BufEnter * match Error /\<FIZZ\|BUZZ\>/
+"マクロが定義されていて、TRUEになるもの
+autocmd BufEnter * 2match Underlined /\<HOGE\|FUGA\>/


### PR DESCRIPTION
実務で使っている設定に更新する。

◾️そもそもvimの設定ってどうやるの？
[1].vimrc
.vimrcの場所を知る方法
:version
[出力結果]
システム vimrc: "/etc/vimrc"
ユーザ vimrc: "$HOME/.vimrc"

.vimrcについてはシステムvimrcとユーザvimrcの二種類がある。
システムvimrc → ユーザvimrc の順番で読み込まれ、重複する設定はユーザーvimrcで上書きされる。
注意点として、ユーザで参照先が複数ある時、ファイルが見つかった時点でそれ以降のファイルは読み込まれなくなる。

[2]runtimepathでディレクトリを読み込む
runtimepathでディレクトリを読み込む順番を知る方法
:set runtimepath
[出力結果]
~/.vim,
/usr/share/vim/vimfiles,
/usr/share/vim/vim74,
/usr/share/vim/vimfiles/after,
~/.vim/after

.vimrcと違い、全てのパス上のファイルを読んで上書きしていく。

[3]その他
gvimrc(gvimの設定ファイル)
exrc(viの設定ファイル)

参考情報
https://teppeis.hatenablog.com/entry/20080705/1215262928
https://kaworu.jpn.org/vim/vim%E3%81%AE%E8%A8%AD%E5%AE%9A%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB
https://blog.tiqwab.com/2017/01/15/understand-vim-plugin-management.html